### PR TITLE
Handful of fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ pydantic_core==2.18.4
 python-dateutil==2.9.0.post0
 python-magic==0.4.27
 rich==13.7.1
-pytz==2024.1
 six==1.16.0
 sniffio==1.3.1
 typing_extensions==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pydantic==2.7.4
 pydantic_core==2.18.4
 python-dateutil==2.9.0.post0
 python-magic==0.4.27
+rich==13.7.1
 pytz==2024.1
 six==1.16.0
 sniffio==1.3.1

--- a/skeeter_deleter.py
+++ b/skeeter_deleter.py
@@ -1,9 +1,11 @@
 import argparse
 import dateutil.parser
+import httpx
 import magic
 import os
 import rich.progress
 from atproto import CAR, Client, models
+from atproto_client.request import Request
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta
 from functools import partial
@@ -95,6 +97,13 @@ class Credentials:
     password: str
 
     dict = asdict
+
+
+class RequestCustomTimeout(Request):
+    def __init__(self, timeout: httpx.Timeout = httpx.Timeout(120), *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = httpx.Client(follow_redirects=True, timeout=timeout)
+
 
 class SkeeterDeleter:
 
@@ -189,7 +198,7 @@ class SkeeterDeleter:
                  fixed_likes_cursor : str=None,
                  verbosity : int=0,
                  autodelete : bool=False):
-        self.client = Client()
+        self.client = Client(request=RequestCustomTimeout())
         self.client.login(**credentials.dict())
 
         # the parameters are a mess, sorry, this is a to-fix

--- a/skeeter_deleter.py
+++ b/skeeter_deleter.py
@@ -222,7 +222,8 @@ class SkeeterDeleter:
 
     def unlike(self):
         n_unlike = len(self.to_unlike)
-        if not self.autodelete:
+        prompt = None
+        while not self.autodelete and prompt not in ("Y", "n"):
             prompt = input(f"""
 Proceed to unlike {n_unlike} post{'' if n_unlike == 1 else 's'}? WARNING: THIS IS DESTRUCTIVE AND CANNOT BE UNDONE. Y/n: """)
         if self.autodelete or prompt == "Y":
@@ -230,7 +231,8 @@ Proceed to unlike {n_unlike} post{'' if n_unlike == 1 else 's'}? WARNING: THIS I
 
     def delete(self):
         n_delete = len(self.to_delete)
-        if not self.autodelete:
+        prompt = None
+        while not self.autodelete and prompt not in ("Y", "n"):
             prompt = input(f"""
 Proceed to delete {n_delete} post{'' if n_delete == 1 else 's'}? WARNING: THIS IS DESTRUCTIVE AND CANNOT BE UNDONE. Y/n: """)
         if self.autodelete or prompt == "Y":

--- a/skeeter_deleter.py
+++ b/skeeter_deleter.py
@@ -235,7 +235,7 @@ Defaults to 0.""", default=0, type=int)
 Ignore or set to 0 to not set an upper limit. This feature deletes old posts that may be taken out of context or selectively
 misinterpreted, reducing potential harassment. Detaults to 0.""", default=0, type=int)
     parser.add_argument("-d", "--domains-to-protect", help="""A comma separated list of domain names to protect. Posts linking to
-domains in this list will not be auto-deleted regardless of age or virality. Default is empty.""", default=[])
+domains in this list will not be auto-deleted regardless of age or virality. Default is empty.""", default="")
     parser.add_argument("-c", "--fixed-likes-cursor", help="""A complex setting. ATProto pagination through is awkward, and
 it will page through the entire history of your account even if there are no likes to be found. This can make the process take
 a long time to complete. If you have already purged likes, it's possible to simply set a token at a reasonable point in the recent

--- a/skeeter_deleter.py
+++ b/skeeter_deleter.py
@@ -156,7 +156,7 @@ class SkeeterDeleter:
 
     def batch_delete_posts(self) -> None:
         if self.verbosity > 0:
-            print(f"Deleting {len(self.to_unlike)} post{'' if len(self.to_unlike) == 1 else 's'}")
+            print(f"Deleting {len(self.to_delete)} post{'' if len(self.to_delete) == 1 else 's'}")
         for post in rich.progress.track(self.to_delete):
             if self.verbosity == 2:
                 print(f"Deleting: {post.post.record.post} on {post.post.record.created_at}, CID: {post.post.cid}")

--- a/skeeter_deleter.py
+++ b/skeeter_deleter.py
@@ -7,7 +7,7 @@ import rich.progress
 from atproto import CAR, Client, models
 from atproto_client.request import Request
 from dataclasses import dataclass, asdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
 
@@ -25,7 +25,7 @@ class PostQualifier(models.AppBskyFeedDefs.FeedViewPost):
     def is_stale(self, stale_threshold, now) -> bool:
         if stale_threshold == 0:
             return False
-        return dateutil.parser.parse(self.post.record.created_at) <= \
+        return dateutil.parser.parse(self.post.record.created_at).replace(tzinfo=timezone.utc) <= \
             now - timedelta(days=stale_threshold)
 
     def is_protected_domain(self, domains_to_protect) -> bool:
@@ -207,7 +207,7 @@ class SkeeterDeleter:
             'stale_threshold': stale_threshold,
             'domains_to_protect': domains_to_protect,
             'fixed_likes_cursor': fixed_likes_cursor,
-            'now': datetime.now(pytz.UTC),
+            'now': datetime.now(timezone.utc),
         }
         self.verbosity = verbosity
         self.autodelete = autodelete


### PR DESCRIPTION
Things I changed in order to get `python skeeter_deleter.py -s 30 -v` to work for me. Each of these should cherry-pick more or less independently, I think.

* Don't crash if --domains-to-protect isn't provided on the command line: Defaulting to a list causes the script to break at `args.domains_to_protect.split(",")` at line 263 since a list doesn't have a split method.
* Add progress bars: Really just for the first-run experience, basically frivolous
* Extend HTTP timeouts: Searching for likes was repeatedly dying on timeouts for me after the script had been running for a long time; httpx's default timeouts are like 5s.
* Fix TypeError: can't compare offset-naive and offset-aware datetimes: it looks like the atproto times there are parsing as timezone-naive; I'm assuming without checking that these are meant to be UTC
* Reprompt if an unexpected value is received: The script churned for an hour and then I hit "y" and nothing happened, whoops
* Fix verbose print for batch delete: It's using the wrong count right now.

Thanks for the tool!